### PR TITLE
Compliance fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+  "yaml.customTags": [
+    "!And",
+    "!And sequence",
+    "!If",
+    "!If sequence",
+    "!Not",
+    "!Not sequence",
+    "!Equals",
+    "!Equals sequence",
+    "!Or",
+    "!Or sequence",
+    "!FindInMap",
+    "!FindInMap sequence",
+    "!Base64",
+    "!Join",
+    "!Join sequence",
+    "!Cidr",
+    "!Ref",
+    "!Sub",
+    "!Sub sequence",
+    "!GetAtt",
+    "!GetAZs",
+    "!ImportValue",
+    "!ImportValue sequence",
+    "!Select",
+    "!Select sequence",
+    "!Split",
+    "!Split sequence"
+  ]
+}

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -74,7 +74,7 @@ RUN mkdir -p /tmp_home \
 
 # remove test folder for compliance. (i.e. not storing secrets in image)
 RUN rm -rf /opt/conda/lib/python3.8/site-packages/tornado/test
-RUN npm uninstall path-parse -g
+#RUN npm uninstall path-parse -g
 USER ${NB_UID}
 
 EXPOSE 8888

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -74,6 +74,7 @@ RUN mkdir -p /tmp_home \
 
 # remove test folder for compliance. (i.e. not storing secrets in image)
 RUN rm -rf /opt/conda/lib/python3.8/site-packages/tornado/test
+RUN npm uninstall path-parse -g
 USER ${NB_UID}
 
 EXPOSE 8888

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -71,6 +71,9 @@ USER root
 RUN mkdir -p /tmp_home \
  && cp -r ${HOME} /tmp_home \
  && chown -R ${NB_USER}:users /tmp_home
+
+# remove test folder for compliance. (i.e. not storing secrets in image)
+RUN rm -f /opt/conda/lib/python3.8/site-packages/tornado/test
 USER ${NB_UID}
 
 EXPOSE 8888

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -73,7 +73,7 @@ RUN mkdir -p /tmp_home \
  && chown -R ${NB_USER}:users /tmp_home
 
 # remove test folder for compliance. (i.e. not storing secrets in image)
-RUN rm -f /opt/conda/lib/python3.8/site-packages/tornado/test
+RUN rm -rf /opt/conda/lib/python3.8/site-packages/tornado/test
 USER ${NB_UID}
 
 EXPOSE 8888


### PR DESCRIPTION
Add the below, line 76, to the jupyter Dockerfile. This removes this test folder that contains a key file;
```
RUN rm -rf /opt/conda/lib/python3.8/site-packages/tornado/test
```